### PR TITLE
v7.11.0

### DIFF
--- a/Modules/Article/Console/InsertDemoContents.php
+++ b/Modules/Article/Console/InsertDemoContents.php
@@ -4,13 +4,11 @@ namespace Modules\Article\Console;
 
 use Auth;
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
 use Illuminate\Support\Facades\DB;
 use Modules\Article\Entities\Category;
 use Modules\Article\Entities\Post;
-use Modules\Tag\Entities\Tag;
 use Modules\Comment\Entities\Comment;
+use Modules\Tag\Entities\Tag;
 
 class InsertDemoContents extends Command
 {
@@ -49,7 +47,7 @@ class InsertDemoContents extends Command
 
         $fresh = $this->option('fresh');
 
-        if($fresh) {
+        if ($fresh) {
             if ($this->confirm('Database tables (posts, categories, tags, comments) will become empty. Confirm truncate tables?')) {
                 
                 // Disable foreign key checks!

--- a/Modules/Article/Console/InsertDemoContents.php
+++ b/Modules/Article/Console/InsertDemoContents.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Modules\Article\Console;
+
+use Auth;
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Illuminate\Support\Facades\DB;
+use Modules\Article\Entities\Category;
+use Modules\Article\Entities\Post;
+use Modules\Tag\Entities\Tag;
+
+class InsertDemoContents extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'starter:insert-demo-data {--fresh}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Insert demo data for posts, categories, tags, and comments. --fresh option will truncate the tables.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        Auth::loginUsingId(1);
+
+        $fresh = $this->option('fresh');
+        // $this->info("a $fresh");
+
+        if($fresh) {
+            if ($this->confirm('Database tables (posts, categories, tags, comments) will become empty. Confirm truncate tables?')) {
+                // Disable foreign key checks!
+                DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+
+                /**
+                 * posts table truncate
+                 */
+                DB::table("posts")->truncate();
+                $this->info("Truncate Table: posts");
+
+                /**
+                 * Categories table truncate
+                 */
+                DB::table("categories")->truncate();
+                $this->info("Truncate Table: categories");
+
+                /**
+                 * Tags table truncate
+                 */
+                DB::table("tags")->truncate();
+                $this->info("Truncate Table: tags");
+
+                /**
+                 * Comments table truncate
+                 */
+                DB::table("comments")->truncate();
+                $this->info("Truncate Table: comments");
+
+                // Enable foreign key checks!
+                DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+            }
+        }
+
+        /**
+         * Categories
+         */
+        $this->info("Inserting Categories");
+        factory(Category::class, 5)->create();
+
+        /**
+         * Tags
+         */
+        $this->info("Inserting Tags");
+        factory(Tag::class, 10)->create();
+
+        /**
+         * Posts
+         */
+        $this->info("Inserting Posts");
+        factory(Post::class, 25)->create()->each(function ($post) {
+            $post->tags()->attach(
+                Tag::inRandomOrder()->limit(rand(5, 10))->pluck('id')->toArray()
+            );
+        });
+
+        $this->info("-- END --");
+    }
+}

--- a/Modules/Article/Console/InsertDemoContents.php
+++ b/Modules/Article/Console/InsertDemoContents.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\DB;
 use Modules\Article\Entities\Category;
 use Modules\Article\Entities\Post;
 use Modules\Tag\Entities\Tag;
+use Modules\Comment\Entities\Comment;
 
 class InsertDemoContents extends Command
 {
@@ -83,6 +84,8 @@ class InsertDemoContents extends Command
             }
         }
 
+        $this->line("");
+
         /**
          * Categories
          */
@@ -105,6 +108,12 @@ class InsertDemoContents extends Command
             );
         });
 
-        $this->info("-- END --");
+        /**
+         * Comments
+         */
+        $this->info("Inserting Comments");
+        factory(Comment::class, 25)->create();
+
+        $this->info("\n\n -- Completed --");
     }
 }

--- a/Modules/Article/Console/InsertDemoContents.php
+++ b/Modules/Article/Console/InsertDemoContents.php
@@ -48,10 +48,10 @@ class InsertDemoContents extends Command
         Auth::loginUsingId(1);
 
         $fresh = $this->option('fresh');
-        // $this->info("a $fresh");
 
         if($fresh) {
             if ($this->confirm('Database tables (posts, categories, tags, comments) will become empty. Confirm truncate tables?')) {
+                
                 // Disable foreign key checks!
                 DB::statement('SET FOREIGN_KEY_CHECKS=0;');
 
@@ -84,7 +84,7 @@ class InsertDemoContents extends Command
             }
         }
 
-        $this->line("");
+        $this->line("\n");
 
         /**
          * Categories

--- a/Modules/Article/Database/Seeders/ArticleDatabaseSeeder.php
+++ b/Modules/Article/Database/Seeders/ArticleDatabaseSeeder.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Modules\Article\Entities\Category;
 use Modules\Article\Entities\Post;
+use Modules\Tag\Entities\Tag;
 
 class ArticleDatabaseSeeder extends Seeder
 {
@@ -42,9 +43,9 @@ class ArticleDatabaseSeeder extends Seeder
 
         // Populate the pivot table
         factory(Post::class, 25)->create()->each(function ($post) {
-            // $post->tags()->attach(
-            //     $tags->random(rand(1, 3))->pluck('id')->toArray()
-            // );
+            $post->tags()->attach(
+                Tag::inRandomOrder()->limit(rand(1, 5))->pluck('id')->toArray()
+            );
         });
         echo " Insert: posts \n";
 

--- a/Modules/Comment/Database/factories/CommentFactory.php
+++ b/Modules/Comment/Database/factories/CommentFactory.php
@@ -3,12 +3,14 @@
 use Carbon\Carbon;
 use Faker\Generator as Faker;
 
-$factory->define(Modules\Article\Entities\Comment::class, function (Faker $faker) {
+$factory->define(Modules\Comment\Entities\Comment::class, function (Faker $faker) {
     return [
         'name'              => $faker->sentence(2),
         'slug'              => '',
         'comment'           => $faker->paragraph,
-        'user_id'           => encode_id($faker->numberBetween(1, 4)),
+        'user_id'           => $faker->numberBetween(1, 4),
+        'commentable_id'    => $faker->numberBetween(1, 25),
+        'commentable_type'  => 'Modules\Article\Entities\Post',
         'status'            => $faker->randomElement([0, 1]),
         'moderated_by'      => $faker->numberBetween(1, 2),
         'moderated_at'      => Carbon::now(),

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Pass: secret
 
 ```
 
+For additional demo data you may use the following command. By using this you can truncate the `posts, categories, tags and comments` table and insert new demo data. `--fresh` option will truncate the tables, without this command new set to data will be inserted only. 
+
+```
+
+php artisan starter:insert-demo-data --fresh
+
+```
+
 # Custom Commands
 
 We have created a number of custom commands for the project. The commands are listed below with a brief about the use of it.
@@ -143,4 +151,3 @@ __Backend Dashboard__
 ---
 
 ![Edit-Posts-Laravel-Starter](https://user-images.githubusercontent.com/396987/88519360-d1bcf880-d013-11ea-9f6c-b5d33912057f.jpg)
-

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["framework", "laravel", "cms", "starter", "admin", "admin dashboard"],
     "license": "GPL-3.0-or-later",
     "type": "project",
-    "version": "v7.10.0",
+    "version": "v7.11.0",
     "require": {
         "php": "^7.2.5",
         "alexusmai/laravel-file-manager": "^2.4",


### PR DESCRIPTION
## Added 
* An artisan command to populate the demo data. The command is the following, `php artisan starter:insert-demo-data --fresh`. The `--fresh` option will truncate the `posts`, `categories`, `tags`, and `comments` table database tables.

## Updated
* Comment table factory