### PR TITLE
fixed passing glue string after array

### DIFF
--- a/resources/views/vendor/log-viewer/laravel-starter/show.blade.php
+++ b/resources/views/vendor/log-viewer/laravel-starter/show.blade.php
@@ -273,7 +273,7 @@ Log Viewer Dashboard | {{ app_name() }}
             $('.stack-content').each(function() {
                 var $this = $(this);
                 var html = $this.html().trim()
-                    .replace(/({!! join(log_styler()->toHighlight(), '|') !!})/gm, '<strong>$1</strong>');
+                    .replace(/({!! join('|', log_styler()->toHighlight()) !!})/gm, '<strong>$1</strong>');
 
                 $this.html(html);
             });


### PR DESCRIPTION
join(): Passing glue string after array is deprecated. Swap the parameters at ../resources/views/vendor/log-viewer/laravel-starter/show.blade.php:281)