### PR TITLE
fix: Profile Encoding Id Issues

### DIFF
--- a/app/Http/Controllers/Frontend/UserController.php
+++ b/app/Http/Controllers/Frontend/UserController.php
@@ -139,7 +139,6 @@ class UserController extends Controller
 
         if ($id != auth()->user()->id) {
             return redirect()->route('frontend.users.profile', encode_id($id));
-
         }
 
         $$module_name_singular = $module_model::findOrFail($id);
@@ -317,7 +316,6 @@ class UserController extends Controller
      */
     public function update(Request $request, $id)
     {
-        
         $module_name = $this->module_name;
         $module_name_singular = Str::singular($this->module_name);
 

--- a/app/Http/Controllers/Frontend/UserController.php
+++ b/app/Http/Controllers/Frontend/UserController.php
@@ -138,7 +138,8 @@ class UserController extends Controller
         }
 
         if ($id != auth()->user()->id) {
-            return redirect()->route('frontend.users.profile', $id);
+            return redirect()->route('frontend.users.profile', encode_id($id));
+
         }
 
         $$module_name_singular = $module_model::findOrFail($id);
@@ -160,6 +161,7 @@ class UserController extends Controller
      */
     public function profileUpdate(Request $request, $id)
     {
+        $id = decode_id($id);
         $module_title = $this->module_title;
         $module_name = $this->module_name;
         $module_path = $this->module_path;
@@ -167,9 +169,8 @@ class UserController extends Controller
         $module_model = $this->module_model;
         $module_name_singular = Str::singular($module_name);
         $module_action = 'Profile Update';
-
         if ($id != auth()->user()->id) {
-            return redirect()->route('frontend.users.profile', $id);
+            return redirect()->route('frontend.users.profile', encode_id($id));
         }
 
         $this->validate($request, [
@@ -210,7 +211,7 @@ class UserController extends Controller
 
         event(new UserProfileUpdated($user_profile));
 
-        return redirect()->route('frontend.users.profile', $$module_name_singular->id)->with('flash_success', 'Update successful!');
+        return redirect()->route('frontend.users.profile', encode_id($$module_name_singular->id))->with('flash_success', 'Update successful!');
     }
 
     /**
@@ -221,6 +222,8 @@ class UserController extends Controller
      */
     public function changePassword($id)
     {
+        $id = decode_id($id);
+
         $module_title = $this->module_title;
         $module_name = $this->module_name;
         $module_path = $this->module_path;
@@ -232,7 +235,7 @@ class UserController extends Controller
         $body_class = 'profile-page';
 
         if ($id != auth()->user()->id) {
-            return redirect()->route('frontend.users.profile', $id);
+            return redirect()->route('frontend.users.profile', encode_id($id));
         }
 
         $id = auth()->user()->id;
@@ -290,7 +293,7 @@ class UserController extends Controller
         $module_action = 'Edit';
 
         if ($id != auth()->user()->id) {
-            return redirect()->route('frontend.users.profile', $id);
+            return redirect()->route('frontend.users.profile', encode_id($id));
         }
 
         $roles = Role::get();
@@ -314,11 +317,12 @@ class UserController extends Controller
      */
     public function update(Request $request, $id)
     {
+        
         $module_name = $this->module_name;
         $module_name_singular = Str::singular($this->module_name);
 
         if ($id != auth()->user()->id) {
-            return redirect()->route('frontend.users.profile', $id);
+            return redirect()->route('frontend.users.profile', encode_id($id));
         }
 
         $$module_name_singular = User::findOrFail($id);
@@ -393,6 +397,8 @@ class UserController extends Controller
      */
     public function emailConfirmationResend($id)
     {
+        $id = decode_id($id);
+
         if ($id != auth()->user()->id) {
             if (auth()->user()->hasAnyRole(['administrator', 'super admin'])) {
                 Log::info(auth()->user()->name.' ('.auth()->user()->id.') - User Requested for Email Verification.');

--- a/resources/views/frontend/users/changePassword.blade.php
+++ b/resources/views/frontend/users/changePassword.blade.php
@@ -13,7 +13,7 @@
                     @auth
                     @if(auth()->user()->id == $$module_name_singular->id)
                     <small>
-                        <a href="{{ route('frontend.users.profileEdit', $$module_name_singular->id) }}" class="btn btn-primary btn-sm">Show</a>
+                        <a href="{{ route('frontend.users.profileEdit', encode_id($$module_name_singular->id)) }}" class="btn btn-primary btn-sm">Show</a>
                     </small>
                     @endif
                     @endauth
@@ -23,7 +23,7 @@
                 </p>
                 @if ($$module_name_singular->email_verified_at == null)
                 <p class="lead">
-                    <a href="{{route('frontend.users.emailConfirmationResend', $$module_name_singular->id)}}">Confirm Email</a>
+                    <a href="{{route('frontend.users.emailConfirmationResend', encode_id($$module_name_singular->id))}}">Confirm Email</a>
                 </p>
                 @endif
 


### PR DESCRIPTION
A fix to #406 where profiles were matching on the encoded versions on the frontend user controller
the check was doing effectively: 1 != 'kwm' so never got past authorisation.
