### PR TITLE
fix user_registration helper error and profile front page error for manually registered users

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -28,7 +28,7 @@ if (! function_exists('user_registration')) {
     {
         $user_registration = false;
 
-        if (env('USER_REGISTRATION') === 'true') {
+        if (env('USER_REGISTRATION') === true) {
             $user_registration = true;
         }
 

--- a/resources/views/frontend/users/profile.blade.php
+++ b/resources/views/frontend/users/profile.blade.php
@@ -118,7 +118,7 @@
             <div class="flex justify-between p-4">
                 <div class="">
                     <span class="font-semibold">{{ label_case($field_name = 'date_of_birth'); }}: </span>
-                    <span class="">{{ $$module_name_singular->$field_name->toFormattedDateString(); }}</span>
+                    <span class="">{{ $$module_name_singular->$field_name ? $$module_name_singular->$field_name->toFormattedDateString() : ''  }}</span>
                 </div>
                 <div class="">
                     <span class="font-semibold">{{ label_case($field_name = 'gender'); }}: </span>


### PR DESCRIPTION
when registration is set to true in the env file the register button does not appear on the front page because the comparison in the user_registration helper uses a string while the env file is bolean and accessing the profile page of the registered user will have an error because the date_of_birth field is empty