### PR TITLE
feat: Add Turkish language support to available locales

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -89,6 +89,7 @@ return [
         'bn' => 'বাংলা (BN)',
         'en' => 'English (EN)',
         'fa' => 'فارسی (FA)',
+        'tr' => 'Türkçe (TR)',
         'vi' => 'Vietnamese (VI)',
     ],
 


### PR DESCRIPTION
- Add Turkish (tr) as 'Türkçe (TR)' to app.php available_locales configuration
- Turkish language files were already available from PR #645 analysis
- Turkish uses LTR (left-to-right) direction, so no additional config needed
- Language selector components will automatically show Turkish option