### PR TITLE
Fix PHPUnit configuration for module tests directory path

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
             <directory>tests/Feature</directory>
         </testsuite>
         <testsuite name="Module">
-            <directory>../laravel-starter-packages/module-manager/src/Modules/*/Tests</directory>
+            <directory>vendor/nasirkhan/module-manager/src/Modules/*/Tests</directory>
         </testsuite>
     </testsuites>
     <source>


### PR DESCRIPTION
This pull request updates the `phpunit.xml` configuration to point the "Module" test suite to the correct directory for module tests.

Configuration update:

* Changed the "Module" test suite directory from a relative path to the `vendor/nasirkhan/module-manager` location, ensuring that PHPUnit runs the correct set of module tests.