### PR TITLE
Fix auth layout: remove leftover @fluxScripts and update gradient class

### DIFF
--- a/resources/views/layouts/auth.blade.php
+++ b/resources/views/layouts/auth.blade.php
@@ -3,7 +3,7 @@
     <head>
         @include('partials.head')
     </head>
-    <body class="min-h-screen bg-white antialiased dark:bg-linear-to-b dark:from-neutral-950 dark:to-neutral-900">
+    <body class="min-h-screen bg-white antialiased dark:bg-gradient-to-b dark:from-neutral-950 dark:to-neutral-900">
         <x-selected-theme />
         <div class="bg-background flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
             <div class="flex w-full max-w-sm flex-col gap-2">
@@ -18,6 +18,6 @@
                 </div>
             </div>
         </div>
-        @fluxScripts
+        @livewireScripts
     </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes the auth layout issue reported in Discussion #812: `@fluxScripts` rendered as raw text on auth pages, alongside a `MultipleRootElementsDetectedException` and uncompiled Tailwind classes.

## Changes

`resources/views/layouts/auth.blade.php`:
- Removed the leftover Livewire Flux directive `@fluxScripts` and render `@livewireScripts` instead, matching `resources/views/layouts/app.blade.php`. The project uses standard Livewire (`livewire/livewire` ^4.0), Flowbite, and Tailwind CSS, with no Flux dependency, so the Flux directive is never registered and prints as plain text.
- Replaced the incompatible gradient class `dark:bg-linear-to-b` with `dark:bg-gradient-to-b` (keeping the `dark:from-neutral-950 dark:to-neutral-900` stops).

## Verification

- Confirmed `@fluxScripts`/Flux appears nowhere else in the codebase (auth layout was the only reference).
- Confirmed `composer.json` has no `livewire/flux` dependency.
- The change mirrors the script-directive convention already used in the main app layout.